### PR TITLE
Max out deploy timeout to allow for indexing rake task to complete

### DIFF
--- a/.ebextensions/seed.config
+++ b/.ebextensions/seed.config
@@ -1,3 +1,8 @@
 container_commands:
   01_db_seed:
     command: bundle exec rake demo:seed
+
+option_settings:
+  - namespace: aws:elasticbeanstalk:command
+    option_name: Timeout
+    value: 3600


### PR DESCRIPTION
deploys with increased indexing was failing due to the fault deploy timeout of 600 seconds. This increases the timeout to the maximum of 3600 (1hr).