### PR TITLE
Adds back the git ebextension install

### DIFF
--- a/.ebextensions/git.config
+++ b/.ebextensions/git.config
@@ -1,0 +1,3 @@
+packages:
+  yum:
+    git: []


### PR DESCRIPTION
We still need git on the machines for our blacklight clone via Gemfile. Removed in error.