### PR TITLE
Adjust time for indexing cron job

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,5 +1,6 @@
 set :output, 'log/seed_cron.log'
 
-every :day, at: '2:00 pm' do
+# EC2 servers default to UTC. 9:15 PM UTC = 2:15 PM PDT/1:15 PM PST 
+every :day, at: '9:15 pm' do
   rake 'demo:seed'
 end


### PR DESCRIPTION
EC2 servers default to UTC, so the 2 PM job was originally scheduled to run
at 7 AM PDT instead. This changes the job to run at 9 PM UTC (or 2 PM PDT/1 PM PST).