### PR TITLE
Update dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ end
 
 gem 'blacklight', github: 'projectblacklight/blacklight'
 gem 'arclight'
-gem 'blacklight_range_limit', github: 'projectblacklight/blacklight_range_limit', branch: 'blacklight-7'
+gem 'blacklight_range_limit', '~> 7.0.0.rc2'
 
 gem 'rsolr', '~> 1.0'
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,17 +10,6 @@ GIT
       nokogiri (~> 1.6)
       rails (~> 5.0)
 
-GIT
-  remote: https://github.com/projectblacklight/blacklight_range_limit.git
-  revision: 9b1d1664167fd2d673f5e4f8eeb042e75129167c
-  branch: blacklight-7
-  specs:
-    blacklight_range_limit (6.1.2)
-      blacklight
-      jquery-rails
-      rails (>= 3.0)
-      tether-rails
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -69,6 +58,11 @@ GEM
     arel (8.0.0)
     bcrypt (3.1.12)
     bindex (0.5.0)
+    blacklight_range_limit (7.0.0.rc2)
+      blacklight
+      jquery-rails
+      rails (>= 3.0)
+      tether-rails
     builder (3.2.3)
     byebug (10.0.2)
     chronic (0.10.2)
@@ -263,7 +257,7 @@ PLATFORMS
 DEPENDENCIES
   arclight
   blacklight!
-  blacklight_range_limit!
+  blacklight_range_limit (~> 7.0.0.rc2)
   byebug
   coffee-rails (~> 4.2)
   devise

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,7 +93,7 @@ GEM
     ffi (1.9.25)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
-    honeybadger (3.3.0)
+    honeybadger (3.3.1)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
     jbuilder (2.7.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/projectblacklight/blacklight.git
-  revision: 99878d412c85c8225d6a1cb4a64f3ccb49fa2fe3
+  revision: 253d09fa2960e763738d45e42c006587db3ff457
   specs:
     blacklight (7.0.0.rc1)
       deprecation
@@ -50,9 +50,9 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    arclight (0.1.3)
-      blacklight
-      blacklight_range_limit
+    arclight (0.1.4)
+      blacklight (= 7.0.0.rc1)
+      blacklight_range_limit (= 7.0.0.rc2)
       rails (~> 5.0)
       solr_ead
     arel (8.0.0)


### PR DESCRIPTION
### Notes

6036db9 : `blacklight_range_limit` recently merged the `blacklight-7` branch into master and cut a new release.