### PR TITLE
Configure Dependabot to update GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
We tried individual Dependabot PRs for GitHub action updates in relevancy_dashboard:

https://github.com/sul-dlss/relevancy_dashboard/pull/353

Let's try the grouping functionality here to see if we like having a single PR better/worse.