### PR TITLE
Use released versions of arclight and blacklight

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,8 +60,8 @@ group :production do
   gem 'mysql2'
 end
 
-gem 'blacklight', github: 'projectblacklight/blacklight'
-gem 'arclight', github: 'projectblacklight/arclight'
+gem 'blacklight', '~> 8.1'
+gem 'arclight', '~> 1.1'
 gem 'rsolr', '~> 2.0'
 gem 'devise'
 gem 'devise-guests', '~> 0.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,27 +1,3 @@
-GIT
-  remote: https://github.com/projectblacklight/arclight.git
-  revision: 54bfcb3b44afd98768bc24e131536e5ba968c15d
-  specs:
-    arclight (1.1.2)
-      blacklight (>= 8.0.0, < 9)
-      gretel
-      rails (~> 7.0)
-      traject (~> 3.0)
-      traject_plus (~> 2.0)
-
-GIT
-  remote: https://github.com/projectblacklight/blacklight.git
-  revision: 6c6a72066a6330a815603e839b316958f6321dd7
-  specs:
-    blacklight (8.1.0)
-      globalid
-      i18n (>= 1.7.0)
-      jbuilder (~> 2.7)
-      kaminari (>= 0.15)
-      ostruct (>= 0.3.2)
-      rails (>= 6.1, < 8)
-      view_component (>= 2.66, < 4)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -101,10 +77,24 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
+    arclight (1.1.2)
+      blacklight (>= 8.0.0, < 9)
+      gretel
+      rails (~> 7.0)
+      traject (~> 3.0)
+      traject_plus (~> 2.0)
     base64 (0.2.0)
     bcrypt (3.1.20)
     bigdecimal (3.1.7)
     bindex (0.8.1)
+    blacklight (8.1.0)
+      globalid
+      i18n (>= 1.7.0)
+      jbuilder (~> 2.7)
+      kaminari (>= 0.15)
+      ostruct (>= 0.3.2)
+      rails (>= 6.1, < 8)
+      view_component (>= 2.66, < 4)
     blacklight-locale_picker (1.1.0)
       rails (>= 5.2.3, < 7.2)
     bootsnap (1.18.3)
@@ -360,8 +350,8 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  arclight!
-  blacklight!
+  arclight (~> 1.1)
+  blacklight (~> 8.1)
   blacklight-locale_picker
   bootsnap
   cssbundling-rails (~> 1.1)


### PR DESCRIPTION
This will let us more deliberately update the demo app to run released versions of arclight & blacklight and not pull in possibly breaking changes.